### PR TITLE
chore: add alb_egress_cidrs, remove unused subnets_cidr_blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ $ terraform apply
 | access\_logs\_bucket | n/a | `string` | `null` | no |
 | access\_logs\_enabled | n/a | `bool` | `false` | no |
 | access\_logs\_prefix | n/a | `string` | `null` | no |
+| alb\_egress\_cidrs | n/a | `list(string)` | n/a | yes |
 | containers | n/a | <pre>list(object({<br>    name              = string<br>    backend_port      = number<br>    health_check_port = number<br>    health_check_path = string<br>    domain            = string<br>  }))</pre> | n/a | yes |
 | create\_ecr | n/a | `bool` | `true` | no |
-| name\_prefix | For most of resource names | `string` | `"terraform-es"` | no |
+| name\_prefix | For most of resource names | `string` | n/a | yes |
 | name\_suffix | If omitted, random string is used. | `string` | `""` | no |
-| public\_subnet\_ids | n/a | `list(string)` | `[]` | no |
-| public\_subnets\_cidr\_blocks | n/a | `list(string)` | n/a | yes |
 | route53\_zone\_id | Route53 zone id for kibana\_proxy\_host | `string` | n/a | yes |
+| subnet\_ids | n/a | `list(string)` | `[]` | no |
 | tags | n/a | `map(string)` | `{}` | no |
 | vpc\_id | If you provide vpc\_id, elasticsearch will be deployed in that vpc. Or it is distributed outside the vpc. | `string` | n/a | yes |
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -64,9 +64,9 @@ module "alb_for_fargate" {
   name_prefix         = "fargate-service"
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.public_subnets
-  subnets_cidr_blocks = module.vpc.public_subnets_cidr_blocks
   route53_zone_id     = data.aws_route53_zone.selected.zone_id
   containers          = local.containers
+  alb_egress_cidrs    = module.vpc.public_subnets
 
   access_logs_enabled = true
   access_logs_bucket  = module.s3_bucket_for_logs.s3_bucket_id
@@ -97,6 +97,7 @@ module "ecs_service" {
   ecs_cluster                 = module.alb_for_fargate.aws_ecs_cluster
   ecs_vpc_id                  = module.vpc.vpc_id
   ecs_subnet_ids              = module.vpc.public_subnets  // In this example, use public subnet for pulling docker images.
+                                                           // If you have NAT, you can use private subnets with "assign_public_ip: false"
   assign_public_ip            = true
   ecs_use_fargate             = true
   kms_key_id                  = module.alb_for_fargate.kms_key_arn

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ module "alb_security_group" {
   ]
 
   egress_with_cidr_blocks = flatten([
-    for i, cidr_block in var.subnets_cidr_blocks : [for port in local.backend_ports : {
+    for i, cidr_block in var.alb_egress_cidrs : [for port in local.backend_ports : {
       from_port   = port
       to_port     = port
       protocol    = "tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "subnet_ids" {
   default = []
 }
 
-variable "subnets_cidr_blocks" {
+variable "alb_egress_cidrs" {
   type = list(string)
 }
 


### PR DESCRIPTION
fix #2 

- alb sg egress 규칙에 들어가는 cidr 목록을 별도로 전달 받도록 `alb_egress_cidrs` 추가
- 사용하지 않는 variable 삭제 및 subnet 사용 관련 코멘트 내용 보강